### PR TITLE
docs: tighten README and lead Quick start with orche init

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,26 @@
 
 https://github.com/user-attachments/assets/35150d31-84ce-4f1d-8df9-4aef179dc532
 
-orche is two things:
+orche runs your coding agents in isolated git worktrees, so several can work at once without stepping on each other. When an agent finishes, you review its diff in a desktop app and send comments straight back to its terminal.
 
-- **`orche start <task>`** — spins up a tmux/cmux session with your agent, dev server, and any other tools you need, each running in an isolated git worktree so agents never step on each other.
-- **`orche review`** — opens a desktop app to review the agent's changes, add line-level comments, and send feedback directly back into the agent's terminal.
-- **`orche prune`** — interactive multiselect for cleaning up worktrees you no longer need.
+Three commands do the work:
 
-### Typical workflow
+- `orche start <task>` opens a tmux or cmux session with your agent, a dev server, and a spare terminal, each in its own worktree.
+- `orche review` opens the review app for a worktree. Leave line-level comments, hit submit, and the feedback lands in the agent's pane.
+- `orche prune` cleans up the worktrees you're done with.
 
-1. Run `orche start fix-auth` — a session opens (tmux or cmux) with your agent (Claude, Codex, etc.), a dev server, and a spare terminal
-2. The agent works on the task in its own worktree
-3. When it's done, either tell the agent to run `orche review` or trigger it yourself from the spare terminal
-4. Review the diff, leave comments, hit submit — feedback lands in the agent's pane
-5. Move on to the next task
+### How it works
+
+1. Run `orche start fix-auth`. A session opens with your agent (Claude, Codex, whatever you configured), a dev server, and a spare terminal.
+2. The agent works in its own worktree.
+3. When it's done, run `orche review`, or tell the agent to.
+4. Read the diff, leave comments, submit. The feedback goes to the agent's pane.
+5. On to the next task.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) (v18+)
-- [tmux](https://github.com/tmux/tmux) or [cmux](https://cmux.dev/) — terminal multiplexer for session management
+- [Node.js](https://nodejs.org/) v18 or newer
+- [tmux](https://github.com/tmux/tmux) or [cmux](https://cmux.dev/) for session management
 - [git](https://git-scm.com/)
 
 ## Installation
@@ -36,7 +38,13 @@ npm install -g @taranek/orche
 
 ## Quick start
 
-1. Create a `.orche.json` in your project root:
+From inside a git repo, run:
+
+```bash
+orche init
+```
+
+That writes a starter `.orche.json` and adds `.orche/` to your `.gitignore`. Open the config and set the panes you want, an agent and a dev server to start with:
 
 ```json
 {
@@ -50,55 +58,41 @@ npm install -g @taranek/orche
 }
 ```
 
-2. Start a session:
+Then start a session:
 
 ```bash
 orche start fix-auth
 ```
 
-This will:
-- Create an isolated git worktree in `.orche/worktrees/`
-- Open a tmux/cmux session with your configured pane layout
-- Run the specified commands in each pane
+This creates a worktree under `.orche/worktrees/`, opens a tmux or cmux session with your panes, and runs each pane's command. When you want to look at the result, run `orche review`.
 
-3. Review changes:
-
-```bash
-orche review
-```
-
-Opens the desktop review app for the current worktree.
-
-## Usage
+## Commands
 
 ```
-orche start <task> [-p <preset>]   Start a new session for <task>
+orche init [-f]                    Bootstrap .orche.json + .gitignore entry
+orche start <task> [-p <preset>]   Start a session for <task>
 orche review [path]                Open the review UI for a worktree
-orche prune [--all] [-f]           Remove orche worktrees (interactive multiselect)
+orche prune [--all] [-f]           Remove orche worktrees
 ```
-
-### Examples
 
 ```bash
-orche start fix-auth               # Create worktree + session for "fix-auth"
-orche start fix-auth -p mobile     # Use .orche.mobile.json preset
-orche start fix-auth --preset=debug  # Use .orche.debug.json preset
-orche review                       # Review changes in current directory
-orche review ./worktree            # Review changes in a specific worktree
-orche prune                        # Pick worktrees to remove
-orche prune --all                  # Remove every orche worktree
-orche prune --force                # Remove worktrees even if they have uncommitted changes
+orche init                         # write .orche.json + ignore .orche/
+orche start fix-auth               # worktree + session for "fix-auth"
+orche start fix-auth -p mobile     # use .orche.mobile.json
+orche review                       # review the current directory
+orche review ./worktree            # review a specific worktree
+orche prune                        # pick worktrees to remove
+orche prune --all                  # remove every orche worktree
+orche prune --force                # remove even with uncommitted changes
 ```
 
-### Pruning worktrees
-
-`orche prune` lists every worktree under `.orche/worktrees/` in an interactive multiselect. Worktrees with uncommitted changes are marked and skipped during removal unless you pass `--force`. Use `--all` to skip the prompt and target every orche worktree at once.
+`orche prune` lists every worktree under `.orche/worktrees/` in a multiselect. Anything with uncommitted changes is flagged and skipped unless you pass `--force`.
 
 ## Configuration
 
 ### `.orche.json`
 
-Defines the pane layout for your session. Place it in your project root. Works with both tmux and cmux.
+This file defines your pane layout. Put it in the project root; it works with both tmux and cmux. Splits can nest as deep as you need:
 
 ```json
 {
@@ -118,7 +112,7 @@ Defines the pane layout for your session. Place it in your project root. Works w
 }
 ```
 
-This produces:
+That config produces:
 
 ```
 ┌─────────────────┬─────────────────┐
@@ -128,21 +122,17 @@ This produces:
 └─────────────────┴─────────────────┘
 ```
 
-**Layout options:**
-
 | Field | Type | Description |
 |-------|------|-------------|
 | `direction` | `"horizontal"` \| `"vertical"` | Split direction |
-| `panes` | array | List of panes or nested splits |
+| `panes` | array | Panes or nested splits |
 | `name` | string | Pane label |
 | `command` | string | Command to run in the pane |
 | `size` | number | Split percentage (optional) |
 
-Layouts can be nested arbitrarily deep.
-
 ### Multiplexer
 
-orche auto-detects whether you're running inside tmux or [cmux](https://cmux.dev/). You can also set it explicitly in your config:
+orche detects whether you're in tmux or [cmux](https://cmux.dev/). To force one, set it in your config:
 
 ```json
 {
@@ -151,32 +141,28 @@ orche auto-detects whether you're running inside tmux or [cmux](https://cmux.dev
 }
 ```
 
-Supported values: `"tmux"` (default) or `"cmux"`.
+Use `"tmux"` (the default) or `"cmux"`.
 
 ### `.orche.local.json`
 
-Same format as `.orche.json`. If present, it takes priority over `.orche.json`. This file is gitignored by default, so you can use it for personal overrides without affecting the team config.
+Same format as `.orche.json`, and it wins when both exist. It's gitignored by default, so it's the place for personal overrides that shouldn't touch the team config.
 
 ### Presets
 
-Create named preset files like `.orche.mobile.json`, `.orche.debug.json`, etc. Use them with the `-p` flag:
+Name a preset file `.orche.<name>.json` and load it with `-p`:
 
 ```bash
 orche start fix-auth -p mobile    # loads .orche.mobile.json
 orche start fix-auth -p debug     # loads .orche.debug.json
 ```
 
-When a preset is specified, it takes priority over both `.orche.json` and `.orche.local.json`. If the preset file doesn't exist, orche will list all available presets in the current directory.
+A preset overrides both `.orche.json` and `.orche.local.json`. Ask for one that doesn't exist and orche lists the presets it can find.
 
 ## Review app
 
-The review app is a desktop application for reviewing agent-produced code changes before they land.
+`orche review` opens a desktop app to look over an agent's changes before they land. Run it from inside a worktree, or pass a path. If you're in a tmux or cmux session, the review links to the agent's pane automatically, so submitted feedback gets pasted straight into the terminal.
 
-Run `orche review` from inside a worktree (or pass a path) to open it. If you're in a tmux or cmux session, the review is automatically linked to the agent's pane — submitted feedback gets pasted straight into the terminal.
-
-### Interface
-
-The app has three panels:
+The window has three columns:
 
 ```
 ┌──────┬────────────┬──────────────────────────────────┐
@@ -189,18 +175,9 @@ The app has three panels:
 └──────┴────────────┴──────────────────────────────────┘
 ```
 
-- **Icon rail** — switch between file tree, comments, and theme panels
-- **Side panel** — browse changed files (with `+`/`~`/`-` status indicators), view pending comments, or switch themes
-- **Diff viewer** — virtualized multi-file split diff with syntax highlighting, collapsible unchanged regions, and sticky file headers
+The icon rail switches between the file tree, comments, and theme panels. The side panel browses changed files (with `+`/`~`/`-` status) or your pending comments. The diff viewer is a virtualized split diff with syntax highlighting, collapsible unchanged regions, and sticky file headers.
 
-### Reviewing workflow
-
-1. Open the review app with `orche review`
-2. Scroll through all changed files in a single view — the sidebar highlights the current file as you scroll
-3. Click any line in the diff to add a comment (or use the `+` gutter button on hover)
-4. Submit with `Cmd+Enter` (macOS) or `Ctrl+Enter` (Linux) — your comments are saved as a markdown file in `.orche/reviews/` and pasted directly into the agent's pane
-
-**Keyboard shortcuts:**
+To review: scroll through every changed file in one view (the sidebar tracks where you are), click a line to comment, then submit with `Cmd+Enter` on macOS or `Ctrl+Enter` on Linux. Your comments are saved as markdown under `.orche/reviews/` and pasted into the agent's pane.
 
 | Key | Action |
 |-----|--------|
@@ -209,18 +186,14 @@ The app has three panels:
 | `Shift+Enter` (in comment) | Newline |
 | `Escape` (in comment) | Cancel |
 
-### Themes
+Four color themes ship with the app and persist between sessions:
 
-Four built-in color themes, persisted across sessions:
-
-- **Obsidian** — dark, warm amber accent
-- **Porcelain** — light, slate-blue accent
-- **Sandstone** — warm light, burnt orange accent
-- **Arctic** — dark, teal accent
+- Obsidian: dark, with a warm amber accent
+- Porcelain: light, with a slate-blue accent
+- Sandstone: warm light, with a burnt orange accent
+- Arctic: dark, with a teal accent
 
 ## Contributing
-
-### Setup
 
 ```bash
 git clone https://github.com/taranek/orche.git
@@ -230,24 +203,22 @@ pnpm run build
 pnpm run link:cli
 ```
 
-Requires [pnpm](https://pnpm.io/) for workspace management.
-
-### Development
+Workspace management uses [pnpm](https://pnpm.io/). Common scripts:
 
 ```bash
-pnpm run dev:cli           # Watch + rebuild CLI (linked globally)
-pnpm run dev:review        # Run review app in dev mode
-pnpm run build             # Build all packages
-pnpm run typecheck         # Type-check all packages
+pnpm run dev:cli           # watch + rebuild the CLI (linked globally)
+pnpm run dev:review        # run the review app in dev mode
+pnpm run build             # build all packages
+pnpm run typecheck         # type-check all packages
 ```
 
-### Project structure
+The code lives in three packages:
 
 ```
 packages/
-  cli/       @orche/cli      — CLI for session and worktree management
-  review/    @orche/review   — Electron code review app
-  shared/    @orche/shared   — Shared components, themes, and state
+  cli/       @orche/cli      CLI for session and worktree management
+  review/    @orche/review   Electron code review app
+  shared/    @orche/shared   shared components, themes, and state
 ```
 
 ## License


### PR DESCRIPTION
Make the README more concise and remove AI writing tells (em dashes, inline-header bullet lists, filler). Merge the duplicated Usage/Examples sections into one Commands section. Document orche init in Quick start and the command list. packages/cli/README.md is a symlink to this file, so both stay in sync.